### PR TITLE
Fixing Authority URL

### DIFF
--- a/TodoListWebApp/App_Start/Startup.Auth.cs
+++ b/TodoListWebApp/App_Start/Startup.Auth.cs
@@ -25,7 +25,7 @@ namespace TodoListWebApp
             string appKey = ConfigurationManager.AppSettings["ida:Password"];
             string graphResourceID = "https://graph.windows.net";
             //fixed address for multitenant apps in the public cloud
-            string Authority = "https://loginmicrosoftonline.com/common/";
+            string Authority = "https://login.microsoftonline.com/common/";
 
             app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
 


### PR DESCRIPTION
It was causing this error: "A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond 199.59.243.120:443"